### PR TITLE
Ensure that values are byte-aligned according to Go standard

### DIFF
--- a/homogenous.go
+++ b/homogenous.go
@@ -20,7 +20,8 @@ type Encoder struct {
 	t reflect.Type
 }
 
-// NewEncoder creates an Encoder that writes memdumps to the provided writer
+// NewEncoder creates an Encoder that writes memdumps to the provided writer.
+// Each object passed to Encode must be of the same type.
 func NewEncoder(w io.Writer) *Encoder {
 	return &Encoder{
 		w: w,
@@ -52,6 +53,9 @@ func (e *Encoder) Encode(obj interface{}) error {
 
 		e.t = t
 		_, err = e.w.Write(delim)
+		if err != nil {
+			return fmt.Errorf("error writing delimeter: %v", err)
+		}
 	}
 
 	// first segment: write the object data

--- a/relocate.go
+++ b/relocate.go
@@ -63,6 +63,16 @@ func relocate(buf []byte, ptrs []int64, main int64, t reflect.Type) (interface{}
 	if len(buf) == 0 {
 		return nil, fmt.Errorf("cannot relocate an empty buffer")
 	}
+
+	// If the buffer is not aligned then we have to move the
+	// whole thing. We can assume that a freshly allocated
+	// buffer from make() is 8-byte aligned.
+	if uintptr(unsafe.Pointer(&buf[0]))%uintptr(t.Align()) != 0 {
+		buf2 := make([]byte, len(buf))
+		copy(buf2, buf)
+		buf = buf2
+	}
+
 	base := uintptr(unsafe.Pointer(&buf[0]))
 	for i, loc := range ptrs {
 		if loc < 0 || loc >= int64(len(buf)) {

--- a/serialize.go
+++ b/serialize.go
@@ -159,8 +159,6 @@ func (e *memEncoder) Encode(ptr interface{}) ([]int64, error) {
 		blockaddr := cur.src.Addr()
 		blockbytes := asBytes(cur.src)
 
-		fmt.Printf("at %d (%v)\n", e.w.offset, cur.src.Type())
-
 		// check the position of the writer
 		if cur.dest < uintptr(e.w.offset) {
 			panic(fmt.Sprintf("block.dest=%d but writer is at %d", cur.dest, e.w.offset))
@@ -168,7 +166,6 @@ func (e *memEncoder) Encode(ptr interface{}) ([]int64, error) {
 
 		// for byte-alignment purposes we may need to fill some bytes
 		if fill := cur.dest - uintptr(e.w.offset); fill > 0 {
-			fmt.Println("filling", fill)
 			_, err := e.w.Write(make([]byte, fill))
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Ensure that values are allocated at byte-aligned positions as per https://go101.org/article/memory-layout.html